### PR TITLE
nix: switch to overlays for package creation

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,6 +1,17 @@
 {
+  inputs,
+  self,
+  ...
+}: {
   imports = [
-    ./packages
     ./devShells
+    ./overlays
+    ./packages
   ];
+  perSystem = {system, ...}: {
+    _module.args.pkgs = import inputs.nixpkgs {
+      inherit system;
+      overlays = [self.overlays.default];
+    };
+  };
 }

--- a/nix/devShells/default.nix
+++ b/nix/devShells/default.nix
@@ -1,15 +1,15 @@
 {
-  perSystem = {
-    config,
-    pkgs,
-    ...
-  }: {
+  perSystem = {pkgs, ...}: {
     devShells = {
-      cuda-redist-find-features = pkgs.mkShell {
-        strictDeps = true;
-        inputsFrom = [config.packages.cuda-redist-find-features];
-        packages = config.packages.cuda-redist-find-features.optional-dependencies.dev;
-      };
+      cuda-redist-find-features = let
+        inherit (pkgs.python3Packages) cuda-redist-find-features;
+        inherit (cuda-redist-find-features.optional-dependencies) dev;
+      in
+        pkgs.mkShell {
+          strictDeps = true;
+          inputsFrom = [cuda-redist-find-features];
+          packages = dev;
+        };
     };
   };
 }

--- a/nix/overlays/default.nix
+++ b/nix/overlays/default.nix
@@ -1,0 +1,12 @@
+{
+  flake.overlays.default = final: prev: {
+    regen-readme = final.callPackage ../packages/regen-readme {};
+    pythonPackagesExtensions =
+      prev.pythonPackagesExtensions
+      ++ [
+        (pythonFinal: _: {
+          cuda-redist-find-features = pythonFinal.callPackage ../packages/cuda-redist-find-features.nix {};
+        })
+      ];
+  };
+}

--- a/nix/packages/cuda-redist-find-features.nix
+++ b/nix/packages/cuda-redist-find-features.nix
@@ -1,5 +1,5 @@
 {
-  buildPythonApplication,
+  buildPythonPackage,
   lib,
   # propagatedBuildInputs
   click,
@@ -43,4 +43,4 @@
     };
   };
 in
-  buildPythonApplication attrs
+  buildPythonPackage attrs

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -1,7 +1,8 @@
 {
   perSystem = {pkgs, ...}: {
     packages = {
-      cuda-redist-find-features = pkgs.python3Packages.callPackage ./cuda-redist-find-features.nix {};
+      inherit (pkgs) regen-readme;
+      inherit (pkgs.python3Packages) cuda-redist-find-features;
     };
   };
 }

--- a/nix/packages/regen-readme/default.nix
+++ b/nix/packages/regen-readme/default.nix
@@ -1,0 +1,8 @@
+{writeShellApplication}: let
+  name = "regen-readme";
+in
+  writeShellApplication {
+    inherit name;
+    runtimeInputs = [];
+    text = ./. + "/${name}.sh";
+  }

--- a/nix/packages/regen-readme/regen-readme.sh
+++ b/nix/packages/regen-readme/regen-readme.sh
@@ -1,0 +1,1 @@
+# shellcheck shell=bash


### PR DESCRIPTION
Creating the packages in the overlay allows us to inherit them from `pkgs` in `./packages` and `./devShells`.

It also allows us to expose the packages in a composable way.