### PR TITLE
add linux-all to platforms

### DIFF
--- a/cuda_redist_find_features/types/_platform.py
+++ b/cuda_redist_find_features/types/_platform.py
@@ -8,6 +8,7 @@ from ._pydantic import PydanticFrozenField, PydanticTypeAdapter
 
 _Platform = Literal[
     "linux-aarch64",
+    "linux-all",
     "linux-ppc64le",
     "linux-sbsa",
     "linux-x86_64",


### PR DESCRIPTION
CUDA 12.8 contains package with platform "linux-all"

add this to platforms